### PR TITLE
get_with_authentication

### DIFF
--- a/autoload/gista.vim
+++ b/autoload/gista.vim
@@ -281,6 +281,7 @@ let s:settings = {
       \ 'suppress_not_owner_acwrite_info_message': 0,
       \ 'warn_in_partial_save': 1,
       \ 'hide_private_gistid': 1,
+      \ 'get_with_authentication': 0,
       \}
 function! s:deprecated(name, replacement) " {{{
   if exists("g:gista#" . a:name)

--- a/autoload/gista/gist/api.vim
+++ b/autoload/gista/gist/api.vim
@@ -77,6 +77,7 @@ endfunction " }}}
 function! gista#gist#api#get(gistid, ...) abort " {{{
   let settings = extend({
         \ 'nocache': 0,
+        \ 'with_authentication': g:gista#get_with_authentication,
         \}, get(a:000, 0, {}))
 
   if !settings.nocache

--- a/autoload/gista/gist/raw.vim
+++ b/autoload/gista/gist/raw.vim
@@ -296,11 +296,16 @@ endfunction " }}}
 
 " API
 function! gista#gist#raw#get(gistid, ...) abort " {{{
-  let settings = extend({}, get(a:000, 0, {}))
+  let settings = extend({
+        \ 'with_authentication': 0
+        \}, get(a:000, 0, {}))
 
-  " get does not require authentication (private gist can be shown if the user
-  " know the url)
-  let header = s:get_anonymous_header()
+  if settings.with_authentication
+    let authenticated_user = gista#gist#raw#get_authenticated_user()
+    let header = gista#gist#raw#login(authenticated_user)
+  else
+    let header = s:get_anonymous_header()
+  endif
   let request_settings = gista#utils#vital#omit(settings, [])
 
   redraw | echo 'Requesting a gist (' . a:gistid . ') ...'

--- a/doc/vim-gista.txt
+++ b/doc/vim-gista.txt
@@ -702,6 +702,13 @@ g:gista#warn_in_partial_save
 	a partial part of content to the connected gist.
 	The default value is 1.
 
+					*g:gista#get_with_authentication*
+g:gista#get_with_authentication
+	In usual, you can get gists with no authentication. But you need to be
+	authenticated in certain circumstances such as strictly restricted
+	Github Enterprise. You may try this option in such time.
+	The default value is 0.
+
 ------------------------------------------------------------------------------
 Commands				*vim-gista-interface-commands*
 


### PR DESCRIPTION
Github Enterprise で利用したところ、gist を読めない場合がありました。どうやらGithub:E の設定によっては get するだけでも認証が必要な状態になるようです。

このため、`g:gista#get_with_authentication` というフラグを追加して、このフラグが真値の場合は認証を行った上で get するようにしてみました。