### PR TITLE
fix typo in guess_extension

### DIFF
--- a/autoload/gista/utils.vim
+++ b/autoload/gista/utils.vim
@@ -80,7 +80,7 @@ function! gista#utils#guess_extension(filetype) " {{{
   elseif has_key(s:consts.EXTMAP, a:filetype)
     return s:consts.EXTMAP[a:filetype]
   endif
-  return '.' + a:filetype
+  return '.' . a:filetype
 endfunction " }}}
 function! gista#utils#input_yesno(message, ...) "{{{
   " forked from Shougo/unite.vim


### PR DESCRIPTION
Because of typo, `gista#utils#guess_extension` returns `0` when the specified filetype is unknown. `a:filetype` is a string, so must be joined not by `+` but by `.`.