### PR TITLE
Import default username from 'git config github.user'

### DIFF
--- a/autoload/gista/client.vim
+++ b/autoload/gista/client.vim
@@ -5,6 +5,7 @@ let s:V = gista#vital()
 let s:C = s:V.import('System.Cache')
 let s:P = s:V.import('System.Filepath')
 let s:G = s:V.import('Web.API.GitHub')
+let s:R = s:V.import('Process')
 
 let s:registry = {}
 let s:current_client = {}
@@ -109,8 +110,8 @@ function! s:get_default_username(apiname) abort
     let default = get(g:gista#client#default_username, '_', '')
     let username = get(g:gista#client#default_username, a:apiname, default)
   endif
-  if empty(username)
-    let username = system('git config github.user')
+  if g:gista#client#use_git_config_github_user && empty(username)
+    let username = s:R.system('git config github.user')
     let username = substitute(username, '\([^\r\n]\+\).*', '\1', '')
   endif
   if empty(username)
@@ -361,6 +362,7 @@ call gista#define_variables('client', {
       \ 'cache_dir': '~/.cache/vim-gista',
       \ 'default_apiname': 'GitHub',
       \ 'default_username': '',
+      \ 'use_git_config_github_user': 1,
       \})
 
 let &cpo = s:save_cpo

--- a/autoload/gista/client.vim
+++ b/autoload/gista/client.vim
@@ -110,6 +110,10 @@ function! s:get_default_username(apiname) abort
     let username = get(g:gista#client#default_username, a:apiname, default)
   endif
   if empty(username)
+    let username = system('git config github.user')
+    let username = substitute(username, '\([^\r\n]\+\).*', '\1', '')
+  endif
+  if empty(username)
     return ''
   endif
   try

--- a/doc/vim-gista.txt
+++ b/doc/vim-gista.txt
@@ -473,6 +473,14 @@ g:gista#client#default_username	*g:gista#client#default_username*
 	A default username used in |:Gista-login| command.
 	Default is ''.
 
+			*g:gista#client#use_git_config_github_user*
+g:gista#client#use_git_config_github_user
+
+	1 to read user's gitconfig.
+	This executes "git config github.user" command
+	and read username from the output.
+	Default is 1.
+
 			*g:gista#command#json#default_opener*
 			*g:gista#command#open#default_opener*
 			*g:gista#command#list#default_opener*


### PR DESCRIPTION
Import default GitHub username from `git config github.user` if it is present.
This PR can get rid of duplicate configuration in .vimrc and .gitconfig .
