### PR TITLE
[Gista fork] Fix E716: Key not present ...

### DIFF
--- a/autoload/gista/command/fork.vim
+++ b/autoload/gista/command/fork.vim
@@ -3,6 +3,7 @@ let s:ArgumentParser = s:V.import('ArgumentParser')
 
 function! gista#command#fork#call(...) abort
   let options = extend({
+        \ 'gist': {},
         \ 'gistid': '',
         \}, get(a:000, 0, {}))
   try


### PR DESCRIPTION
Fixed the following error when `:Gista fork {id}`.

```
E716: 辞書型にキーが存在しません: gist) ? options.gistid : options.gist.id)
E116: 関数の無効な引数です: empty(options.gist) ? options.gistid : options.gist.id)
E116: 関数の無効な引数です: gista#resource#local#get_valid_gistid(empty(options.gist) ? options.gistid : options.gist.id)
E15: 無効な式です: gista#resource#local#get_valid_gistid(empty(options.gist) ? options.gistid : options.gist.id)
```