### PR TITLE
Allow accounts including hyphen

### DIFF
--- a/autoload/gista/resource/local.vim
+++ b/autoload/gista/resource/local.vim
@@ -51,7 +51,7 @@ function! s:validate_lookup(client, lookup) abort
     return
   endif
   call gista#util#validate#pattern(
-        \ a:lookup, '^\w*$',
+        \ a:lookup, '^[-0-9a-zA-Z_]*$',
         \ 'A lookup "%value" requires to follow "%pattern"'
         \)
 endfunction


### PR DESCRIPTION
Account names might have hypen. This patch enables to execute `:Gista list some-name-with-hyphen`.