### PR TITLE
Fix gist ID validation error.

### DIFF
--- a/autoload/gista/resource/local.vim
+++ b/autoload/gista/resource/local.vim
@@ -34,7 +34,7 @@ function! s:validate_gistid(gistid) abort
         \ 'A gist ID cannot be empty',
         \)
   call gista#util#validate#pattern(
-        \ a:gistid, '^\w\{,20}\%(/\w\+\)\?$',
+        \ a:gistid, '^\w\{,32}\%(/\w\+\)\?$',
         \ 'A gist ID "%value" requires to follow "%pattern"'
         \)
 endfunction


### PR DESCRIPTION
Gist IDが32桁になった関係でValidationエラーが出たため修正しました。